### PR TITLE
Fix embeded enums

### DIFF
--- a/src/de/enum_.rs
+++ b/src/de/enum_.rs
@@ -115,6 +115,17 @@ impl<'a, 'de> de::VariantAccess<'de> for StructVariantAccess<'a, 'de> {
     where
         V: de::Visitor<'de>,
     {
-        de::Deserializer::deserialize_struct(self.de, "", fields, visitor)
+        let value = de::Deserializer::deserialize_struct(&mut *self.de, "", fields, visitor)?;
+        match self
+            .de
+            .parse_whitespace()
+            .ok_or(Error::EofWhileParsingValue)?
+            {
+                b'}' => {
+                    self.de.eat_char();
+                    Ok(value)
+                }
+                _ => Err(Error::ExpectedSomeValue),
+            }
     }
 }

--- a/src/ser/struct_.rs
+++ b/src/ser/struct_.rs
@@ -66,6 +66,9 @@ impl<'a> ser::SerializeStructVariant for SerializeStruct<'a> {
     }
 
     fn end(self) -> Result<Self::Ok> {
+        // close struct
+        self.de.buf.push(b'}');
+        // close surrounding enum
         self.de.buf.push(b'}');
         Ok(())
     }


### PR DESCRIPTION
We were missing a trailing } both in de and ser when parsing (non-newtype / embedded) enum structs. It was symetrical, but not valid json.

Now this is fixed, and compatible with typical parsers.