### PR TITLE
Add newtype string support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .#*
 /target
 Cargo.lock
+.idea

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -518,11 +518,11 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     }
 
     /// Unsupported. We can’t parse newtypes because we don’t know the underlying type.
-    fn deserialize_newtype_struct<V>(self, _name: &'static str, _visitor: V) -> Result<V::Value>
+    fn deserialize_newtype_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        unreachable!()
+        visitor.visit_newtype_struct(self)
     }
 
     fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value>

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -877,6 +877,20 @@ mod tests {
         );
     }
 
+    #[derive(Deserialize, Clone, Debug, PartialEq)]
+    pub struct Address(pub String);
+
+    #[derive(Deserialize, Clone, Debug, PartialEq)]
+    pub struct NewtypeDemo {
+        pub address: Address,
+    }
+
+    #[test]
+    fn newtypes() {
+        let c: NewtypeDemo = crate::from_str(r#"{"address": "johnny"}"#).unwrap();
+        assert_eq!(Address("johnny".to_string()), c.address);
+    }
+
     #[test]
     fn deserialize_optional_vector() {
         #[derive(Debug, Deserialize, PartialEq)]


### PR DESCRIPTION
This allows structs defining newtypes to deserialize properly. eg:

```rust
    #[derive(Deserialize, Clone, Debug, PartialEq)]
    pub struct Address(pub String);

    #[derive(Deserialize, Clone, Debug, PartialEq)]
    pub struct NewtypeDemo {
        pub address: Address,
    }
```